### PR TITLE
Enhancement: Remove unneeded `output` and `error` functions in `docker-entrypoint.sh`

### DIFF
--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -5,23 +5,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -30,9 +22,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.12-mysqlclient-openssl/docker-entrypoint.sh
+++ b/variants/3.12-mysqlclient-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.12-mysqlclient/docker-entrypoint.sh
+++ b/variants/3.12-mysqlclient/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.12-openssl/docker-entrypoint.sh
+++ b/variants/3.12-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.12/docker-entrypoint.sh
+++ b/variants/3.12/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.15-mysqlclient-openssl/docker-entrypoint.sh
+++ b/variants/3.15-mysqlclient-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.15-mysqlclient/docker-entrypoint.sh
+++ b/variants/3.15-mysqlclient/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.15-openssl/docker-entrypoint.sh
+++ b/variants/3.15-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.15/docker-entrypoint.sh
+++ b/variants/3.15/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.17-mysqlclient-openssl/docker-entrypoint.sh
+++ b/variants/3.17-mysqlclient-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.17-mysqlclient/docker-entrypoint.sh
+++ b/variants/3.17-mysqlclient/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.17-openssl/docker-entrypoint.sh
+++ b/variants/3.17-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.17/docker-entrypoint.sh
+++ b/variants/3.17/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.8-mysqlclient-openssl/docker-entrypoint.sh
+++ b/variants/3.8-mysqlclient-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.8-mysqlclient/docker-entrypoint.sh
+++ b/variants/3.8-mysqlclient/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.8-openssl/docker-entrypoint.sh
+++ b/variants/3.8-openssl/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else

--- a/variants/3.8/docker-entrypoint.sh
+++ b/variants/3.8/docker-entrypoint.sh
@@ -4,23 +4,15 @@ set -eu
 # This makes environment variables available to everyone, including crond and its crons
 env > /etc/environment
 
-output() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1"
-}
-
-error() {
-    echo -e "[$( date -u '+%Y-%m-%dT%H:%M:%S%z' )] $1" >&2
-}
-
 # Default to root as the cron user
 CRON_USER=${CRON_USER:-root}
 CRON=${CRON:-}
-output "Will use user $CRON_USER for crons."
+echo "Will use user $CRON_USER for crons."
 
 # Check if the cron user exists
 id "$CRON_USER" >/dev/null 2>&1
 if [ ! $? = 0 ]; then
-    error "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!"
+    echo "User '$CRON_USER' specified by \$CRON_USER environment variable does not exist on the system!" >&2
     exit 1
 fi
 
@@ -29,9 +21,9 @@ CRONTAB="/var/spool/cron/crontabs/$CRON_USER"
 
 # Create our crontab from the env var if present
 if [ -n "$CRON" ]; then
-    output "Creating crontab $CRONTAB"
+    echo "Creating crontab $CRONTAB"
     echo -e "$CRON" > "$CRONTAB"
-    output "Setting owner and permissions on crontab: $CRONTAB"
+    echo "Setting owner and permissions on crontab: $CRONTAB"
     chown "$CRON_USER:$CRON_USER" "$CRONTAB"
     chmod 600 "$CRONTAB"
 else


### PR DESCRIPTION
Timestamps should be part of the logging driver (e.g. docker logging driver), which can be seen by doing `docker logs --timestamps`, so there's no need to log timestamps at all.
